### PR TITLE
(INT-2112) Improve Bot Framework Composer template

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This section collects prerequisites that have to be fulfilled for certain `vendo
 
 >Information on **how to connect messaging channels** to your Conversational Cloud account:
 >
->1. [Apple Business Chat](https://knowledge.liveperson.com/messaging-channels-apple-business-chat-setup-guide.html)
+>1. [Apple Business Chat](https://knowledge.liveperson.com/messaging-channels-apple-messages-for-business-setup-guide.html)
 >2. [Facebook](https://knowledge.liveperson.com/messaging-channels-facebook-messenger.html)
 >3. [Google Business Messages](https://knowledge.liveperson.com/messaging-channels-google-google-business-messages.html#setting-up-google-business-messages)
 >4. [Google RCS Business Messaging](https://knowledge.liveperson.com/messaging-channels-google-google-rcs-business-messaging.html#setting-up-google-rcs)

--- a/src/vendors/microsoft/composer/composer.ts
+++ b/src/vendors/microsoft/composer/composer.ts
@@ -49,7 +49,8 @@ type Action = {
 type Trigger = {
     $kind: string;
     $designer?: unknown;
-    intent: string;
+    condition?: string;
+    intent?: string;
     actions: Action[];
 };
 
@@ -117,14 +118,19 @@ function createActionForMainDialog(intent: string, index: number): Action {
  * @return {Trigger}
  */
 function createTriggerForMainDialog(actions: Action[], intent: string): Trigger {
-    return {
-        $kind: intent === 'welcome' ? 'Microsoft.OnConversationUpdateActivity' : 'Microsoft.OnIntent',
-        intent,
+    const trigger: Trigger = {
+        $kind: intent === 'welcome' ? 'Microsoft.OnMessageActivity' : 'Microsoft.OnIntent',
         $designer: {
-            name: intent,
+            name: intent === 'welcome' ? 'LP Welcome Message' : intent,
         },
         actions,
     };
+    if (intent === 'welcome') {
+        trigger.condition = "=exists(turn.Activity.channelData.action.name) && turn.Activity.channelData.action.name == 'WELCOME'";
+    } else {
+        trigger.intent = intent;
+    }
+    return trigger;
 }
 
 /**

--- a/tests/unit/vendors/helper.ts
+++ b/tests/unit/vendors/helper.ts
@@ -4476,11 +4476,11 @@ export const composerResult = [
                     ],
                 },
                 {
-                    $kind: 'Microsoft.OnConversationUpdateActivity',
-                    intent: 'welcome',
+                    $kind: 'Microsoft.Microsoft.OnMessageActivity',
                     $designer: {
-                        name: 'welcome',
+                        name: 'Message received (Message received activity)',
                     },
+                    condition: "=exists(turn.Activity.channelData.action.name) && turn.Activity.channelData.action.name == 'WELCOME'",
                     actions: [
                         {
                             $kind: 'Microsoft.SendActivity',


### PR DESCRIPTION
Send Initial Message on LP welcome message instead of the conversationUpdate activity since this is the only activity Third Party Bots considers besides activities that are direct responses to a consumer message. 